### PR TITLE
Add password visibility toggle for Sign In and Sign Up forms

### DIFF
--- a/Algolyzer/templates/account/login.html
+++ b/Algolyzer/templates/account/login.html
@@ -37,23 +37,31 @@
                             <span class="label-text">{{ field.label }}</span>
                         </div>
                     {% else %}
-                        <div class="form-control">
-                            {% comment %} <label for="{{ field.id_for_label }}" class="label">
-                                <span class="label-text">{{ field.label }}</span>
-                            </label> {% endcomment %}
+                        <div class="form-control relative">
                             <input
-                                type="{{ field.type }}"
+                                type="{% if field.name == 'password' %}password{% else %}{{ field.type }}{% endif %}"
                                 name="{{ field.name }}"
                                 id="{{ field.id_for_label }}"
                                 value="{{ field.value|default:'' }}"
                                 placeholder="{{ field.label }}"
                                 class="input input-bordered input-primary"
                             >
+                            {% if field.name == 'password' %}
+                                <button
+                                    type="button"
+                                    class="absolute inset-y-0 right-2 flex items-center btn btn-sm btn-ghost"
+                                    onclick="togglePasswordVisibility('{{ field.id_for_label }}')"
+                                >
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825l4.5-4.5M21 12a9 9 0 11-6-8.47" />
+                                    </svg>
+                                </button>
+                            {% endif %}
                             {% for error in field.errors %}
                                 <span class="text-error text-sm">{{ error }}</span>
                             {% endfor %}
                         </div>
-                        {% endif %}
+                    {% endif %}
                 {% endfor %}
                 
                 {{ redirect_field }}
@@ -95,7 +103,7 @@
     {% if PASSKEY_LOGIN_ENABLED %}
         {% include "mfa/webauthn/snippets/login_script.html" with button_id="passkey_login" %}
     {% endif %}
-<script>
+    <script>
         function togglePasswordVisibility(inputId) {
             const input = document.getElementById(inputId);
             if (input.type === "password") {
@@ -105,5 +113,4 @@
             }
         }
     </script>
-{% endblock %}
-
+{% endblock extra_body %}

--- a/Algolyzer/templates/account/login.html
+++ b/Algolyzer/templates/account/login.html
@@ -49,7 +49,7 @@
                             {% if field.name == 'password' %}
                                 <button
                                     type="button"
-                                    class="absolute inset-y-0 right-2 flex items-center btn btn-sm btn-ghost"
+                                    class="absolute inset-y-0 right-2 flex items-center btn btn-sm btn-ghost transform -translate-y-1/2 top-1/2"
                                     onclick="togglePasswordVisibility('{{ field.id_for_label }}')"
                                 >
                                     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -98,7 +98,7 @@
 </div>
 {% endblock content %}
 
-{% block extra_body %}
+{% block scripts %}
     {{ block.super }}
     {% if PASSKEY_LOGIN_ENABLED %}
         {% include "mfa/webauthn/snippets/login_script.html" with button_id="passkey_login" %}
@@ -113,4 +113,4 @@
             }
         }
     </script>
-{% endblock extra_body %}
+{% endblock scripts %}

--- a/Algolyzer/templates/account/login.html
+++ b/Algolyzer/templates/account/login.html
@@ -95,4 +95,15 @@
     {% if PASSKEY_LOGIN_ENABLED %}
         {% include "mfa/webauthn/snippets/login_script.html" with button_id="passkey_login" %}
     {% endif %}
+<script>
+        function togglePasswordVisibility(inputId) {
+            const input = document.getElementById(inputId);
+            if (input.type === "password") {
+                input.type = "text";
+            } else {
+                input.type = "password";
+            }
+        }
+    </script>
 {% endblock %}
+

--- a/Algolyzer/templates/account/signup.html
+++ b/Algolyzer/templates/account/signup.html
@@ -34,7 +34,7 @@
                     {% if field.name == 'password1' or field.name == 'password2' %}
                         <button
                             type="button"
-                            class="absolute inset-y-0 right-2 flex items-center btn btn-sm btn-ghost"
+                            class="absolute inset-y-0 right-2 flex items-center btn btn-sm btn-ghost transform -translate-y-1/2 top-1/2"
                             onclick="togglePasswordVisibility('{{ field.id_for_label }}')"
                         >
                             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -73,7 +73,7 @@
 </div>
 {% endblock content %}
 
-{% block extra_body %}
+{% block scripts %}
     {{ block.super }}
     <script>
         function togglePasswordVisibility(inputId) {
@@ -85,4 +85,4 @@
             }
         }
     </script>
-{% endblock extra_body %}
+{% endblock scripts %}

--- a/Algolyzer/templates/account/signup.html
+++ b/Algolyzer/templates/account/signup.html
@@ -22,23 +22,31 @@
             <form method="post" action="{% url 'account_signup' %}" class="mt-6 space-y-4">
                 {% csrf_token %}
                 {% for field in form %}
-                <div class="form-control">
-                    {% comment %} <label for="{{ field.id_for_label }}" class="label">
-                        <span class="label-text">{{ field.label }}</span>
-                    </label> {% endcomment %}
+                <div class="form-control relative">
                     <input
-                        type="{{ field.type }}"
+                        type="{% if field.name == 'password1' or field.name == 'password2' %}password{% else %}{{ field.type }}{% endif %}"
                         name="{{ field.name }}"
                         id="{{ field.id_for_label }}"
                         value="{{ field.value|default:'' }}"
                         placeholder="{{field.label}}"
                         class="input input-bordered input-primary"
                     >
+                    {% if field.name == 'password1' or field.name == 'password2' %}
+                        <button
+                            type="button"
+                            class="absolute inset-y-0 right-2 flex items-center btn btn-sm btn-ghost"
+                            onclick="togglePasswordVisibility('{{ field.id_for_label }}')"
+                        >
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825l4.5-4.5M21 12a9 9 0 11-6-8.47" />
+                            </svg>
+                        </button>
+                    {% endif %}
                     {% for error in field.errors %}
                         <span class="text-error text-sm">{{ error }}</span>
                     {% endfor %}
                 </div>
-            {% endfor %}
+                {% endfor %}
                 {{ redirect_field }}
 
                 <button type="submit" class="btn btn-primary btn-block">
@@ -64,3 +72,17 @@
     </div>
 </div>
 {% endblock content %}
+
+{% block extra_body %}
+    {{ block.super }}
+    <script>
+        function togglePasswordVisibility(inputId) {
+            const input = document.getElementById(inputId);
+            if (input.type === "password") {
+                input.type = "text";
+            } else {
+                input.type = "password";
+            }
+        }
+    </script>
+{% endblock extra_body %}


### PR DESCRIPTION
Hii @Priyanshu-Batham 

This PR adds a password visibility toggle to the Sign In and Sign Up templates, improving usability. 

Changes include:
- JavaScript functionality for toggling password visibility.
- Updated password fields with a toggle button and an SVG icon.
- Ensured all password fields are secure by default but can be toggled.

