### PR TITLE
Fix typo that in .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,4 +14,4 @@ DJANGO_SUPERUSER_PASSWORD=admin
 # Uncomment for development
 #CELERY_BROKER_URL=redis://localhost:6379/0
 # Uncomment for production
-#CELERY_BROKER_URL=redis://reids:6379/0
+#CELERY_BROKER_URL=redis://redis:6379/0


### PR DESCRIPTION
`redis` was spelled as `reids` which caused production server to fail.