### PR TITLE
changed the sentiment analysis model

### DIFF
--- a/Algolyzer/playground/management/commands/download_models.py
+++ b/Algolyzer/playground/management/commands/download_models.py
@@ -5,8 +5,7 @@ from transformers import AutoModel, AutoTokenizer
 
 # Define models to download
 MODELS = {
-    "sentiment-analysis": "distilbert-base-uncased-finetuned-sst-2-english",
-    "text-classification": "facebook/bart-large-mnli",
+    "sentiment-analysis": "finiteautomata/bertweet-base-sentiment-analysis",
 }
 
 # Define directory for saving models

--- a/Algolyzer/playground/tasks.py
+++ b/Algolyzer/playground/tasks.py
@@ -21,7 +21,7 @@ def sentiment_analysis_task(self, task_db_id, input_data):
             settings.BASE_DIR,
             "playground",
             "aiml_models",
-            "distilbert-base-uncased-finetuned-sst-2-english",
+            "finiteautomata_bertweet-base-sentiment-analysis",
         )
 
         # Load model from saved directory
@@ -33,7 +33,7 @@ def sentiment_analysis_task(self, task_db_id, input_data):
 
         if not model:
             raise ValueError(
-                "Model 'distilbert-base-uncased-finetuned-sst-2-english' not found."
+                "Model 'finiteautomata_bertweet-base-sentiment-analysis' not found."
             )
 
         # Process the input with the model


### PR DESCRIPTION
- fixed #110 
- replaced the old `distilbert` model with `finiteautomata/bertweet-base-sentiment-analysis`
- removed the other facebook model.
- downloading aiml models with command `python manage.py download_models` is now optimized.
